### PR TITLE
Relative filepaths for azure

### DIFF
--- a/ToDoFunctions/AddToDoItem.cs
+++ b/ToDoFunctions/AddToDoItem.cs
@@ -23,7 +23,7 @@ namespace ToDoFunctions
     {
         [FunctionName("AddToDoItem")]
         [StorageAccount("MyTable")]
-        public static async Task<HttpResponseMessage> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", "get")]HttpRequestMessage req, [Table("todotable", Connection = "MyTable")]ICollector<ToDoItem> outTable, TraceWriter log)
+        public static async Task<HttpResponseMessage> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", "get")]HttpRequestMessage req, [Table("todotable", Connection = "MyTable")]ICollector<ToDoItem> outTable, TraceWriter log, ExecutionContext context)
         {
             try
             {                
@@ -40,7 +40,8 @@ namespace ToDoFunctions
                 else if(req.Method == HttpMethod.Get)
                 {
                     var response = new HttpResponseMessage(HttpStatusCode.OK);
-                    var stream = new FileStream(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\AddToDo.html", FileMode.Open);
+                    var path = Path.GetFullPath(Path.Combine(context.FunctionDirectory, @"..\"));
+                    var stream = new FileStream(path + "\\AddToDo.html", FileMode.Open);
                     response.Content = new StreamContent(stream);
                     response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
                     return response;

--- a/ToDoFunctions/AddToDoItem.cs
+++ b/ToDoFunctions/AddToDoItem.cs
@@ -15,6 +15,7 @@ using System.Net.Http.Headers;
 using System.Configuration;
 using Microsoft.WindowsAzure.Storage;
 using System.Diagnostics;
+using System.Reflection;
 
 namespace ToDoFunctions
 {
@@ -39,7 +40,7 @@ namespace ToDoFunctions
                 else if(req.Method == HttpMethod.Get)
                 {
                     var response = new HttpResponseMessage(HttpStatusCode.OK);
-                    var stream = new FileStream(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName) + "AddToDo.html", FileMode.Open);
+                    var stream = new FileStream(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\AddToDo.html", FileMode.Open);
                     response.Content = new StreamContent(stream);
                     response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
                     return response;

--- a/ToDoFunctions/CompletetoDoItem.cs
+++ b/ToDoFunctions/CompletetoDoItem.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Diagnostics;
+using System.Reflection;
 
 namespace ToDoFunctions
 {
@@ -25,7 +26,7 @@ namespace ToDoFunctions
             outTable.ExecuteAsync(operation);
 
             var response = new HttpResponseMessage(HttpStatusCode.OK);
-            var stream = new FileStream(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName) + "/Index.html", FileMode.Open);
+            var stream = new FileStream(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\Index.html", FileMode.Open);
             response.Content = new StreamContent(stream);
             response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
             return response;

--- a/ToDoFunctions/CompletetoDoItem.cs
+++ b/ToDoFunctions/CompletetoDoItem.cs
@@ -17,7 +17,7 @@ namespace ToDoFunctions
     public static class CompleteToDoItem
     {
         [FunctionName("CompleteToDoItem")]
-        public static HttpResponseMessage Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "CompleteToDoItem/{id}")]HttpRequestMessage req, [Table("todotable", Connection = "MyTable")]IQueryable<ToDoItem> inTable, [Table("todotable", Connection = "MyTable")]CloudTable outTable, string id, TraceWriter log)
+        public static HttpResponseMessage Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "CompleteToDoItem/{id}")]HttpRequestMessage req, [Table("todotable", Connection = "MyTable")]IQueryable<ToDoItem> inTable, [Table("todotable", Connection = "MyTable")]CloudTable outTable, string id, TraceWriter log, ExecutionContext context)
         {
             var item = inTable.Where(p => p.PartitionKey == id).FirstOrDefault();
             item.IsComplete = true;
@@ -26,7 +26,8 @@ namespace ToDoFunctions
             outTable.ExecuteAsync(operation);
 
             var response = new HttpResponseMessage(HttpStatusCode.OK);
-            var stream = new FileStream(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\Index.html", FileMode.Open);
+            var path = Path.GetFullPath(Path.Combine(context.FunctionDirectory, @"..\"));
+            var stream = new FileStream(path + "\\Index.html", FileMode.Open);
             response.Content = new StreamContent(stream);
             response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
             return response;

--- a/ToDoFunctions/ReturnIndexPage.cs
+++ b/ToDoFunctions/ReturnIndexPage.cs
@@ -15,10 +15,11 @@ namespace ToDoFunctions
     public static class ReturnIndexPage
     {
         [FunctionName("HomePage")]
-        public static HttpResponseMessage Run([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)]HttpRequestMessage req, [Table("todotable", Connection = "MyTable")]ICollector<ToDoItem> outTable, TraceWriter log)
+        public static HttpResponseMessage Run([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)]HttpRequestMessage req, [Table("todotable", Connection = "MyTable")]ICollector<ToDoItem> outTable, TraceWriter log, ExecutionContext context)
         {
             var response = new HttpResponseMessage(HttpStatusCode.OK);
-            var stream = new FileStream(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\Index.html", FileMode.Open);
+            var path = Path.GetFullPath(Path.Combine(context.FunctionDirectory, @"..\"));
+            var stream = new FileStream(path + "\\Index.html", FileMode.Open);
             response.Content = new StreamContent(stream);
             response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
             return response;

--- a/ToDoFunctions/ReturnIndexPage.cs
+++ b/ToDoFunctions/ReturnIndexPage.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.WebJobs.Host;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Diagnostics;
+using System.Reflection;
 
 namespace ToDoFunctions
 {
@@ -17,7 +18,7 @@ namespace ToDoFunctions
         public static HttpResponseMessage Run([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)]HttpRequestMessage req, [Table("todotable", Connection = "MyTable")]ICollector<ToDoItem> outTable, TraceWriter log)
         {
             var response = new HttpResponseMessage(HttpStatusCode.OK);
-            var stream = new FileStream(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName) + "Index.html", FileMode.Open);
+            var stream = new FileStream(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\Index.html", FileMode.Open);
             response.Content = new StreamContent(stream);
             response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
             return response;

--- a/ToDoFunctions/ToDoHistory.cs
+++ b/ToDoFunctions/ToDoHistory.cs
@@ -15,10 +15,11 @@ namespace ToDoFunctions
     public static class ToDoHistory
     {
         [FunctionName("ToDoHistory")]
-        public static async Task<HttpResponseMessage> Run([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)]HttpRequestMessage req, TraceWriter log)
+        public static async Task<HttpResponseMessage> Run([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)]HttpRequestMessage req, TraceWriter log, ExecutionContext context)
         {
             var response = new HttpResponseMessage(HttpStatusCode.OK);
-            var stream = new FileStream(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\ToDoHistory.html", FileMode.Open);
+            var path = Path.GetFullPath(Path.Combine(context.FunctionDirectory, @"..\"));
+            var stream = new FileStream(path + "\\ToDoHistory.html", FileMode.Open);          
             response.Content = new StreamContent(stream);
             response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
             return response;

--- a/ToDoFunctions/ToDoHistory.cs
+++ b/ToDoFunctions/ToDoHistory.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.WebJobs.Host;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Diagnostics;
+using System.Reflection;
 
 namespace ToDoFunctions
 {
@@ -17,7 +18,7 @@ namespace ToDoFunctions
         public static async Task<HttpResponseMessage> Run([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)]HttpRequestMessage req, TraceWriter log)
         {
             var response = new HttpResponseMessage(HttpStatusCode.OK);
-            var stream = new FileStream(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName) + "ToDoHistory.html", FileMode.Open);
+            var stream = new FileStream(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\ToDoHistory.html", FileMode.Open);
             response.Content = new StreamContent(stream);
             response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
             return response;

--- a/ToDoFunctions/local.settings.json
+++ b/ToDoFunctions/local.settings.json
@@ -3,6 +3,6 @@
   "Values": {
     "AzureWebJobsStorage": "",
     "AzureWebJobsDashboard": "",
-    "MyTable": "<TableConnectionString>"
+    "MyTable": "DefaultEndpointsProtocol=https;AccountName=todofunctions;AccountKey=NXofOh4G+mv3D00H0Iw8noKkpg+1oOad53gKKZQKkY1CR2cVwLYAWBov5VEeXn0GKcaNBp+v5i1h3rZnbE/17Q==;EndpointSuffix=core.windows.net"
   }
 }


### PR DESCRIPTION
Passed in `ExecutionContext context` to Function Parameters to get access to the file path in the context it is being called. Unfortunately Azure structures its Function files into their own folders, so to get access to HTML files we must move up one level in the directory. 
Example:
~~~~
var path = Path.GetFullPath(Path.Combine(context.FunctionDirectory, @"..\"));
var stream = new FileStream(path + "\\Index.html", FileMode.Open);
~~~~

Reference to `ExecutionContext`:
https://github.com/Azure/azure-webjobs-sdk-script/wiki/Retrieving-information-about-the-currently-running-function