### PR TITLE
Fix paths

### DIFF
--- a/ToDoFunctions/ToDoFunctions.csproj
+++ b/ToDoFunctions/ToDoFunctions.csproj
@@ -120,6 +120,9 @@
     <None Update="StaticFileServer\run.csx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="www\js\ensure-directory-trailing-slash.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="www\js\TodoClient.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/ToDoFunctions/www/angular2/index.html
+++ b/ToDoFunctions/www/angular2/index.html
@@ -1,6 +1,7 @@
 ﻿<!doctype html>
 <html lang="en" data-framework="angular2">
 	<head>
+        <script src="../js/ensure-directory-trailing-slash.js"></script>
 		<meta charset="utf-8">
 		<title>Angular2 • TodoMVC</title>
 		<link rel="stylesheet" href="angular2/node_modules/todomvc-common/base.css">

--- a/ToDoFunctions/www/angular2/index.html
+++ b/ToDoFunctions/www/angular2/index.html
@@ -4,13 +4,13 @@
         <script src="../js/ensure-directory-trailing-slash.js"></script>
 		<meta charset="utf-8">
 		<title>Angular2 • TodoMVC</title>
-		<link rel="stylesheet" href="angular2/node_modules/todomvc-common/base.css">
-		<link rel="stylesheet" href="angular2/node_modules/todomvc-app-css/index.css">
-        <script src="js/TodoClient.js"></script>
-		<script src="angular2/node_modules/angular2/bundles/angular2-polyfills.js"></script>
-		<script src="angular2/node_modules/systemjs/dist/system.src.js"></script>
-		<script src="angular2/node_modules/rxjs/bundles/Rx.js"></script>
-		<script src="angular2/node_modules/angular2/bundles/angular2.dev.js"></script>
+		<link rel="stylesheet" href="node_modules/todomvc-common/base.css">
+		<link rel="stylesheet" href="node_modules/todomvc-app-css/index.css">
+        <script src="../js/TodoClient.js"></script>
+		<script src="node_modules/angular2/bundles/angular2-polyfills.js"></script>
+		<script src="node_modules/systemjs/dist/system.src.js"></script>
+		<script src="node_modules/rxjs/bundles/Rx.js"></script>
+		<script src="node_modules/angular2/bundles/angular2.dev.js"></script>
 	</head>
 	<body>
 		<todo-app></todo-app>

--- a/ToDoFunctions/www/index.html
+++ b/ToDoFunctions/www/index.html
@@ -2,6 +2,7 @@
 
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
+    <script src="../js/ensure-directory-trailing-slash.js"></script>
     <meta charset="utf-8" />
     <title></title>
 </head>

--- a/ToDoFunctions/www/jquery/Index.html
+++ b/ToDoFunctions/www/jquery/Index.html
@@ -2,6 +2,7 @@
 
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
+    <script src="../js/ensure-directory-trailing-slash.js"></script>
     <meta charset="utf-8" />
     <title>Index</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">

--- a/ToDoFunctions/www/js/ensure-directory-trailing-slash.js
+++ b/ToDoFunctions/www/js/ensure-directory-trailing-slash.js
@@ -1,0 +1,8 @@
+﻿// Ensure root directory has trailing slash
+// currently we're not able to do this redirect in the StaticFileServer because the proxy strips off the trailing slash
+(function () {
+    var loc = window.location;
+    if (loc.pathname.match(/\/[^\/\.]+$/)) {
+        window.location.href = loc.pathname + '/' + loc.search + loc.hash;
+    }
+}());

--- a/ToDoFunctions/www/react/index.html
+++ b/ToDoFunctions/www/react/index.html
@@ -4,8 +4,8 @@
         <script src="../js/ensure-directory-trailing-slash.js"></script>
 		<meta charset="utf-8">
 		<title>React • TodoMVC</title>
-		<link rel="stylesheet" href="react/node_modules/todomvc-common/base.css">
-		<link rel="stylesheet" href="react/node_modules/todomvc-app-css/index.css">
+		<link rel="stylesheet" href="node_modules/todomvc-common/base.css">
+		<link rel="stylesheet" href="node_modules/todomvc-app-css/index.css">
 	</head>
 	<body>
 		<section class="todoapp"></section>
@@ -15,20 +15,20 @@
 			<p>Part of <a href="http://todomvc.com">TodoMVC</a></p>
 		</footer>
 
-		<script src="react/node_modules/todomvc-common/base.js"></script>
-		<script src="react/node_modules/react/dist/react-with-addons.js"></script>
-		<script src="react/node_modules/classnames/index.js"></script>
-		<script src="react/node_modules/react/dist/JSXTransformer.js"></script>
-		<script src="react/node_modules/director/build/director.js"></script>
+		<script src="node_modules/todomvc-common/base.js"></script>
+		<script src="node_modules/react/dist/react-with-addons.js"></script>
+		<script src="node_modules/classnames/index.js"></script>
+		<script src="node_modules/react/dist/JSXTransformer.js"></script>
+		<script src="node_modules/director/build/director.js"></script>
 
-		<script src="react/js/utils.js"></script>
-		<script src="react/js/todoModel.js"></script>
+		<script src="js/utils.js"></script>
+		<script src="js/todoModel.js"></script>
+        <script src="../js/TodoClient.js"></script>
 		<!-- jsx is an optional syntactic sugar that transforms methods in React's
 		`render` into an HTML-looking format. Since the two models above are
 		unrelated to React, we didn't need those transforms. -->
-        <script type="text/jsx" src="js/TodoClient.js"></script>
-		<script type="text/jsx" src="react/js/todoItem.jsx"></script>
-		<script type="text/jsx" src="react/js/footer.jsx"></script>
-		<script type="text/jsx" src="react/js/app.jsx"></script>
+		<script type="text/jsx" src="js/todoItem.jsx"></script>
+		<script type="text/jsx" src="js/footer.jsx"></script>
+		<script type="text/jsx" src="js/app.jsx"></script>
 	</body>
 </html>

--- a/ToDoFunctions/www/react/index.html
+++ b/ToDoFunctions/www/react/index.html
@@ -1,6 +1,7 @@
 ﻿<!doctype html>
 <html lang="en" data-framework="react">
 	<head>
+        <script src="../js/ensure-directory-trailing-slash.js"></script>
 		<meta charset="utf-8">
 		<title>React • TodoMVC</title>
 		<link rel="stylesheet" href="react/node_modules/todomvc-common/base.css">


### PR DESCRIPTION
Add a temporary JavaScript hack to redirect all access to directories with default pages to link with a trailing slash (to make it work like a web server)

Should be able to access pages on these paths:
- `/react/`
- `/react/index.html`

And requests to `/react` should redirect to `/react/`.

Need to investigate how to do this redirect from the server side.
